### PR TITLE
MOD-189 - Inline IAM Policies for SSO Permission Sets

### DIFF
--- a/modules/sso/README.md
+++ b/modules/sso/README.md
@@ -97,6 +97,7 @@ No modules.
 | [aws_ssoadmin_account_assignment.users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_account_assignment) | resource |
 | [aws_ssoadmin_managed_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_managed_policy_attachment) | resource |
 | [aws_ssoadmin_permission_set.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set) | resource |
+| [aws_ssoadmin_permission_set_inline_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set_inline_policy) | resource |
 | [aws_identitystore_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/identitystore_group) | data source |
 | [aws_identitystore_user.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/identitystore_user) | data source |
 | [aws_organizations_organization.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
@@ -106,7 +107,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_permission_sets"></a> [permission\_sets](#input\_permission\_sets) | List of the required Permission Sets | `list(any)` | n/a | yes |
+| <a name="input_inline_permission_sets"></a> [inline\_permission\_sets](#input\_inline\_permission\_sets) | List of the required Permission Sets that are comprised of inline IAM Policies | `list(any)` | n/a | yes |
+| <a name="input_managed_permission_sets"></a> [managed\_permission\_sets](#input\_managed\_permission\_sets) | List of the required Permission Sets that contain AWS Managed Policies | `list(any)` | n/a | yes |
 | <a name="input_sandbox_enabled_users"></a> [sandbox\_enabled\_users](#input\_sandbox\_enabled\_users) | List of users who have personal sandbox accounts | `list(string)` | `[]` | no |
 | <a name="input_sso_groups"></a> [sso\_groups](#input\_sso\_groups) | List of the Groups as obtained from the Identity Provider | `list(any)` | `[]` | no |
 | <a name="input_sso_users"></a> [sso\_users](#input\_sso\_users) | List of the Users as obtained from the Identity Provider | `list(any)` | `[]` | no |

--- a/modules/sso/locals.tf
+++ b/modules/sso/locals.tf
@@ -3,8 +3,8 @@ locals {
   sso_instance_arn  = tolist(data.aws_ssoadmin_instances.selected.arns)[0]
   identity_store_id = tolist(data.aws_ssoadmin_instances.selected.identity_store_ids)[0]
 
-  permission_set_attachments = flatten([
-    for set in var.permission_sets : [
+  managed_permission_set_attachments = flatten([
+    for set in var.managed_permission_sets : [
       for policy in set.attached_policies : {
         name        = set.name
         description = set.description
@@ -19,7 +19,6 @@ locals {
         name           = group.name
         permission_set = group.permission_set
         account        = account
-        # principal_type = "GROUP"
       }
     ] if group.accounts != []
   ])
@@ -30,7 +29,6 @@ locals {
         name           = user.name
         permission_set = user.permission_set
         account        = account
-        # principal_type = "USER"
       }
     ] if user.accounts != []
   ])

--- a/modules/sso/variables.tf
+++ b/modules/sso/variables.tf
@@ -1,6 +1,11 @@
-variable "permission_sets" {
+variable "managed_permission_sets" {
   type        = list(any)
-  description = "List of the required Permission Sets"
+  description = "List of the required Permission Sets that contain AWS Managed Policies"
+}
+
+variable "inline_permission_sets" {
+  type        = list(any)
+  description = "List of the required Permission Sets that are comprised of inline IAM Policies"
 }
 
 variable "sso_groups" {


### PR DESCRIPTION
## Related Tasks

A number of PR's relating to MOD-189

## Depends on

N/A

## What

Adds the functionality to attach inline IAM Policies to SSO Permission Sets

## Why

Required to grant selective EC2 access to instances in the imported data-prod AWS member account

## Concerns

None


* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.
