### PR TITLE
feat:  s3 account level PAB to be optional

### DIFF
--- a/modules/baseline/main.tf
+++ b/modules/baseline/main.tf
@@ -10,8 +10,9 @@ resource "aws_iam_account_password_policy" "default" {
 }
 
 
-##  -----  S3 Account Public Block  -----  ##
+##  -----  (Optional) S3 Account Public Block  -----  ##
 resource "aws_s3_account_public_access_block" "this" {
+  count = var.create_s3_account_public_access_block ? 1 : 0
 
   account_id              = var.config.account_id
   block_public_acls       = false

--- a/modules/baseline/variables.tf
+++ b/modules/baseline/variables.tf
@@ -27,3 +27,8 @@ variable "repo" {
   type        = string
   description = "Name of this current repository"
 }
+
+variable "create_s3_account_public_access_block" {
+  type    = bool
+  default = true
+}


### PR DESCRIPTION
## Related Tasks

Franklin.ai AWS ORG setup

## Depends on

None

## What

Configure the S3 account level public access block to be optional

## Why

We have some accounts in Harrison that require public buckets



* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.
