### PR TITLE
feat: delegated sso admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.1.0]
-* Initial version
+
+- Initial version
 
 ## [0.1.1]
-* Released as an Open Source module
+
+- Released as an Open Source module
+
+## [0.1.2]
+
+- Enable the use of Delegated SSO Administration

--- a/examples/sso/locals.tf
+++ b/examples/sso/locals.tf
@@ -11,11 +11,20 @@ locals {
   ]
 
   # maps a permission set to a list of IAM Policies
-  permission_sets = [
+  managed_permission_sets = [
     {
       name              = "AdministratorAccess"
       description       = "Full Administrator Access"
       attached_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+    }
+  ]
+
+  # maps a permission set to an inline IAM Policy (singlular)
+  inline_permission_sets = [
+    {
+      name          = "custom_permission_set"
+      description   = "Description"
+      inline_policy = data.aws_iam_policy_document.custom_permission_set.json
     }
   ]
 

--- a/examples/sso/main.tf
+++ b/examples/sso/main.tf
@@ -1,7 +1,13 @@
 module "sso" {
   source = "../../modules/sso"
 
-  permission_sets = local.permission_sets
-  sso_groups      = local.sso_groups
+  managed_permission_sets = []
+  inline_permission_sets  = local.inline_permission_sets
+  sso_groups              = local.sso_groups
+  sso_users               = []
+
+  #  if delegated sso admin is enabled
+  delegated_sso_admin = true
+  accounts_list       = local.accounts_list
 
 }

--- a/modules/sso/README.md
+++ b/modules/sso/README.md
@@ -1,6 +1,6 @@
 # Terraform AWS SSO
 
-A Terraform module which configures AWS Single Sign On.  Note that there are some pre-requisite manual steps to be configured in the Console before applying any Terraform configuration.
+A Terraform module which configures AWS Single Sign On. Note that there are some pre-requisite manual steps to be configured in the Console before applying any Terraform configuration.
 
 Any supported Identity Provider can be configured, however these instructions will refer to Azure AD.
 
@@ -10,10 +10,10 @@ Note that the following steps are completed in the AWS Console and the Azure AD 
 
 Complete in Azure AD:
 
-- Locate and install the  AWS Single Sign-On app as an Enterprise Application from the App Gallery
+- Locate and install the AWS Single Sign-On app as an Enterprise Application from the App Gallery
 - Obtain the following settings:
-  - IdP sign-in URL / Metadata URL.  This will be in the format: https://login.microsoftonline.com/<tenant-id>/saml2
-  - IdP issuer URL.  This will be in the format: https://sts.windows.net/<tenant-id>/
+  - IdP sign-in URL / Metadata URL. This will be in the format: https://login.microsoftonline.com/<tenant-id>/saml2
+  - IdP issuer URL. This will be in the format: https://sts.windows.net/<tenant-id>/
   - Certificate in raw format
 - Assign the relevant groups and users to the Enterprise App.
 
@@ -25,14 +25,30 @@ Complete in AWS Console:
 - Note the SCIM endpoint and Access Token and pass back to Azure AD.
 - Download the identity file and pass back to Azure AD.
 
-
-- Ensure Auto Provisioning is enabled in Azure AD and ensure you can see the groups/users assigned to the App in the AWS Console |  AWS SSO | Groups
+- Ensure Auto Provisioning is enabled in Azure AD and ensure you can see the groups/users assigned to the App in the AWS Console | AWS SSO | Groups
 
 ## Requirements
 
-AWS SSO should be configured in the Organization Master account
+AWS SSO should be configured in the Organization Master account. See also the section below regarding Delegated SSO Admin
 
 AWS SSO should be included in the Organization Service Access Principals
+
+## Delegated SSO Administration
+
+If Delegated SSO Administation is enabled in this Organisation, you will need to provide this module with a list of member account name to ID mappings as the data source used to obtain this list will not work in this scenario. Note that you will also need to enable the `delegated_sso_admin` attribute in the module. See the examples directory.
+
+```terraform
+accounts_list = [
+  {
+    name = "account-one",
+    id = "123456789012"
+  },
+  {
+    name = "account-two",
+    id = "123456789012"
+  }
+]
+```
 
 ## Terraform Configuration
 
@@ -41,7 +57,6 @@ As an overview:
 - Azure AD Groups/Users appear automatically in AWS SSO | Groups / Users.
 - **Permission Sets** are created, to which IAM Policies are attached.
 - A **Permission Set** is mapped to a Group and to an Account(s).
-
 
 ## Example Data Structures
 
@@ -72,18 +87,19 @@ permission_sets = [
 https://docs.aws.amazon.com/singlesignon/latest/userguide/azure-ad-idp.html
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.10 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| Name                                                                     | Version   |
+| ------------------------------------------------------------------------ | --------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.0.10 |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 4.0    |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| Name                                             | Version |
+| ------------------------------------------------ | ------- |
+| <a name="provider_aws"></a> [aws](#provider_aws) | ~> 4.0  |
 
 ## Modules
 
@@ -91,27 +107,29 @@ No modules.
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_ssoadmin_account_assignment.groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_account_assignment) | resource |
-| [aws_ssoadmin_account_assignment.users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_account_assignment) | resource |
-| [aws_ssoadmin_managed_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_managed_policy_attachment) | resource |
-| [aws_ssoadmin_permission_set.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set) | resource |
-| [aws_ssoadmin_permission_set_inline_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set_inline_policy) | resource |
-| [aws_identitystore_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/identitystore_group) | data source |
-| [aws_identitystore_user.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/identitystore_user) | data source |
-| [aws_organizations_organization.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
-| [aws_ssoadmin_instances.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssoadmin_instances) | data source |
+| Name                                                                                                                                                                | Type        |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [aws_ssoadmin_account_assignment.groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_account_assignment)                   | resource    |
+| [aws_ssoadmin_account_assignment.users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_account_assignment)                    | resource    |
+| [aws_ssoadmin_managed_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_managed_policy_attachment)       | resource    |
+| [aws_ssoadmin_permission_set.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set)                             | resource    |
+| [aws_ssoadmin_permission_set_inline_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set_inline_policy) | resource    |
+| [aws_identitystore_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/identitystore_group)                                  | data source |
+| [aws_identitystore_user.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/identitystore_user)                                    | data source |
+| [aws_organizations_organization.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization)                    | data source |
+| [aws_ssoadmin_instances.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssoadmin_instances)                                | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_inline_permission_sets"></a> [inline\_permission\_sets](#input\_inline\_permission\_sets) | List of the required Permission Sets that are comprised of inline IAM Policies | `list(any)` | n/a | yes |
-| <a name="input_managed_permission_sets"></a> [managed\_permission\_sets](#input\_managed\_permission\_sets) | List of the required Permission Sets that contain AWS Managed Policies | `list(any)` | n/a | yes |
-| <a name="input_sandbox_enabled_users"></a> [sandbox\_enabled\_users](#input\_sandbox\_enabled\_users) | List of users who have personal sandbox accounts | `list(string)` | `[]` | no |
-| <a name="input_sso_groups"></a> [sso\_groups](#input\_sso\_groups) | List of the Groups as obtained from the Identity Provider | `list(any)` | `[]` | no |
-| <a name="input_sso_users"></a> [sso\_users](#input\_sso\_users) | List of the Users as obtained from the Identity Provider | `list(any)` | `[]` | no |
+| Name                                                                                                   | Description                                                                              | Type           | Default | Required |
+| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- | -------------- | ------- | :------: |
+| <a name="input_accounts_list"></a> [accounts_list](#input_accounts_list)                               | A list of Member Account Name and ID mappings, required if Delegated SSO Admin is in use | `list(any)`    | `[]`    |    no    |
+| <a name="input_delegated_sso_admin"></a> [delegated_sso_admin](#input_delegated_sso_admin)             | Is Delegated SSO Admin configured in this Organisation?                                  | `bool`         | `false` |    no    |
+| <a name="input_inline_permission_sets"></a> [inline_permission_sets](#input_inline_permission_sets)    | List of the required Permission Sets that are comprised of inline IAM Policies           | `list(any)`    | n/a     |   yes    |
+| <a name="input_managed_permission_sets"></a> [managed_permission_sets](#input_managed_permission_sets) | List of the required Permission Sets that contain AWS Managed Policies                   | `list(any)`    | n/a     |   yes    |
+| <a name="input_sandbox_enabled_users"></a> [sandbox_enabled_users](#input_sandbox_enabled_users)       | List of users who have personal sandbox accounts                                         | `list(string)` | `[]`    |    no    |
+| <a name="input_sso_groups"></a> [sso_groups](#input_sso_groups)                                        | List of the Groups as obtained from the Identity Provider                                | `list(any)`    | `[]`    |    no    |
+| <a name="input_sso_users"></a> [sso_users](#input_sso_users)                                           | List of the Users as obtained from the Identity Provider                                 | `list(any)`    | `[]`    |    no    |
 
 ## Outputs
 

--- a/modules/sso/data.tf
+++ b/modules/sso/data.tf
@@ -1,4 +1,6 @@
-data "aws_organizations_organization" "this" {}
+data "aws_organizations_organization" "this" {
+  count = var.delegated_sso_admin ? 1 : 0
+}
 
 data "aws_ssoadmin_instances" "selected" {}
 

--- a/modules/sso/data.tf
+++ b/modules/sso/data.tf
@@ -1,5 +1,5 @@
 data "aws_organizations_organization" "this" {
-  count = var.delegated_sso_admin ? 1 : 0
+  count = var.delegated_sso_admin ? 0 : 1
 }
 
 data "aws_ssoadmin_instances" "selected" {}

--- a/modules/sso/locals.tf
+++ b/modules/sso/locals.tf
@@ -33,5 +33,5 @@ locals {
     ] if user.accounts != []
   ])
 
-  accounts = var.delegated_sso_admin ? data.aws_organizations_organization.this[0].accounts[*] : var.accounts_list
+  accounts = var.delegated_sso_admin ? var.accounts_list : data.aws_organizations_organization.this[0].accounts[*]
 }

--- a/modules/sso/locals.tf
+++ b/modules/sso/locals.tf
@@ -33,6 +33,5 @@ locals {
     ] if user.accounts != []
   ])
 
-  accounts = data.aws_organizations_organization.this.accounts[*]
-
+  accounts = var.delegated_sso_admin ? data.aws_organizations_organization.this[0].accounts[*] : var.accounts_list
 }

--- a/modules/sso/variables.tf
+++ b/modules/sso/variables.tf
@@ -25,3 +25,15 @@ variable "sandbox_enabled_users" {
   default     = []
   description = "List of users who have personal sandbox accounts"
 }
+
+variable "delegated_sso_admin" {
+  type        = bool
+  default     = false
+  description = "Is Delegated SSO Admin configured in this Organisation?"
+}
+
+variable "accounts_list" {
+  type        = list(any)
+  default     = []
+  description = "A list of Member Account Name and ID mappings, required if Delegated SSO Admin is in use"
+}


### PR DESCRIPTION
## Related Tasks

N/A

## Depends on

N/A

## What

Cater for scenarios where Delegated SSO Administration may be configured.  This means that the `aws_organizations_organization` doesn't return all the attributes we expect and instead have to supply them manually

## Why

One of our consumers of this module has just implemented Delegated SSO Administration

* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.
