### PR TITLE
chore: Allow users of the module to set the session_duration

### DIFF
--- a/examples/sso/locals.tf
+++ b/examples/sso/locals.tf
@@ -22,10 +22,10 @@ locals {
   # maps a permission set to an inline IAM Policy (singlular)
   inline_permission_sets = [
     {
-      name          = "custom_permission_set"
-      description   = "Description"
-      inline_policy = data.aws_iam_policy_document.custom_permission_set.json
+      name             = "custom_permission_set"
+      description      = "Description"
+      inline_policy    = data.aws_iam_policy_document.custom_permission_set.json
+      session_duration = "PT4H" #default is PT12H if unset
     }
   ]
-
 }

--- a/modules/sso/main.tf
+++ b/modules/sso/main.tf
@@ -4,7 +4,7 @@ resource "aws_ssoadmin_permission_set" "this" {
   name             = each.value.name
   description      = each.value.description
   instance_arn     = local.sso_instance_arn
-  session_duration = "PT12H"
+  session_duration = try(each.value.session_duration, "PT12H")
 }
 
 


### PR DESCRIPTION
It's a security best practice to not set the duration length longer than is needed.

Default to 12h still if it's not set, but take a value if given one.