### PR TITLE
tag member accounts

### DIFF
--- a/modules/organization/main.tf
+++ b/modules/organization/main.tf
@@ -31,6 +31,7 @@ resource "aws_organizations_account" "this" {
   iam_user_access_to_billing = each.value.iam_user_access_to_billing
   parent_id                  = each.value.parent.uuid != null ? [for ou in local.org_units : ou.id if ou.uuid == each.value.parent.uuid][0] : aws_organizations_organization.org.roots[0].id
   close_on_deletion          = each.value.close_on_deletion
+  tags                       = try(each.value.tags, {})
 
   depends_on = [
     aws_organizations_organization.org


### PR DESCRIPTION
## Related Tasks

N/A

## Depends on

N/A

## What

Functionality to tag member accounts.  This is to enable a policy that will protect accounts from deletion based on their tag.  A safeguard now that the `close_on_deletion` feature can be enabled.  See also [here](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_close.html#example_policy_tag_close_account)

* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.
