### PR TITLE
Baseline module boolean destroy flag HAI-721

### DIFF
--- a/modules/baseline/README.md
+++ b/modules/baseline/README.md
@@ -17,6 +17,30 @@ module "example" {
   region                      = "ap-southeast-2"
 }
 ```
+### Destroying infra
+
+To avoid massive code repitition, we have broken a Terraform convention and placed the provider within the module for this module. This has the negative side effect of making infra a bit difficult to destroy. (When the module is removed from config, so is the provider) To work around this, destroying infra created from this `baseline` module is a two step process.
+
+1. Add a `destroy = true` variable into the module
+2. Execute `terraform apply` to destroy the infra
+3. Delete the module from composition and execute another `plan` or `apply` to sanity check
+
+By example:
+
+```terraform
+module "user_a" {
+  source = "modules/baseline"
+
+  destroy = true
+
+  config                      = local.individual_sandbox_account_config["user_a@example.com"]
+  central_budget_notification = var.central_budget_notification
+  project                     = var.project
+  repo                        = var.repo
+  profile                     = var.profile
+  region                      = var.region
+}
+```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -52,6 +76,7 @@ No modules.
 | <a name="input_central_budget_notification"></a> [central\_budget\_notification](#input\_central\_budget\_notification) | Central or Shared email address for Budget Notifications | `string` | `""` | no |
 | <a name="input_config"></a> [config](#input\_config) | Map of configuration items | `map(any)` | n/a | yes |
 | <a name="input_create_s3_account_public_access_block"></a> [create\_s3\_account\_public\_access\_block](#input\_create\_s3\_account\_public\_access\_block) | Create the account level S3 Public Access Block | `bool` | `true` | no |
+| <a name="input_destroy"></a> [destroy](#input\_destroy) | Flag to enable deletion of resources where the provider is embedded into the module | `bool` | `false` | no |
 | <a name="input_min_iam_password_length"></a> [min\_iam\_password\_length](#input\_min\_iam\_password\_length) | Minimum length of IAM password | `number` | `64` | no |
 | <a name="input_profile"></a> [profile](#input\_profile) | AWS Shared Credentials Profile | `string` | n/a | yes |
 | <a name="input_project"></a> [project](#input\_project) | Designated project name | `string` | n/a | yes |

--- a/modules/baseline/main.tf
+++ b/modules/baseline/main.tf
@@ -1,5 +1,6 @@
 # ##  -----  Password Policy  -----  ##
 resource "aws_iam_account_password_policy" "default" {
+  count = var.destroy ? 0 : 1
 
   minimum_password_length        = var.min_iam_password_length
   require_lowercase_characters   = true
@@ -12,7 +13,7 @@ resource "aws_iam_account_password_policy" "default" {
 
 ##  -----  (Optional) S3 Account Public Block  -----  ##
 resource "aws_s3_account_public_access_block" "this" {
-  count = var.create_s3_account_public_access_block ? 1 : 0
+  count = (var.destroy || var.create_s3_account_public_access_block == 0) ? 0 : 1
 
   account_id              = var.config.account_id
   block_public_acls       = false
@@ -23,13 +24,15 @@ resource "aws_s3_account_public_access_block" "this" {
 
 ##  -----  Default EBS Encryption  -----  ##
 resource "aws_ebs_encryption_by_default" "this" {
+  count = var.destroy ? 0 : 1
+
   enabled = true
 }
 
 
 ##  -----  Budget  -----  ##
 resource "aws_budgets_budget" "this" {
-  count = var.config.budget_limit_amount != null ? 1 : 0
+  count = (var.destroy || var.config.budget_limit_amount == null) ? 0 : 1
 
   name         = "default-budget"
   budget_type  = "COST"

--- a/modules/baseline/main.tf
+++ b/modules/baseline/main.tf
@@ -73,3 +73,13 @@ resource "aws_budgets_budget" "this" {
     subscriber_email_addresses = compact([var.config.email, var.central_budget_notification])
   }
 }
+
+moved {
+  from = aws_ebs_encryption_by_default.this
+  to   = aws_ebs_encryption_by_default.this[0]
+}
+
+moved {
+  from = aws_iam_account_password_policy.default
+  to   = aws_iam_account_password_policy.default[0]
+}

--- a/modules/baseline/variables.tf
+++ b/modules/baseline/variables.tf
@@ -39,3 +39,9 @@ variable "min_iam_password_length" {
   default     = 64
   description = "Minimum length of IAM password"
 }
+
+variable "destroy" {
+  type        = bool
+  default     = false
+  description = "Flag to enable deletion of resources where the provider is embedded into the module"
+}


### PR DESCRIPTION
## What

Add a boolean flag into the baseline module to ease the process of destroying infra where the provider is embedded into the module

## Why

Provider is embedded into the `baseline` module to prevent massive code repetition.  This is somewhat of a Terraform anti-pattern and makes destroying infra a little harder


* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.
