### PR TITLE
Extend sample to include block vpc tag renaming

### DIFF
--- a/examples/organization/data.tf
+++ b/examples/organization/data.tf
@@ -8,7 +8,8 @@ data "aws_iam_policy_document" "sandbox" {
     data.aws_iam_policy_document.deny_internet_access.json,
     data.aws_iam_policy_document.deny_create_vpc.json,
     data.aws_iam_policy_document.deny_modify_budget.json,
-    data.aws_iam_policy_document.protect_org_roles.json
+    data.aws_iam_policy_document.protect_org_roles.json,
+    data.aws_iam_policy_document.deny_modify_vpc_tags.json,
   ]
 }
 
@@ -169,6 +170,23 @@ data "aws_iam_policy_document" "deny_modify_budget" {
       "budgets:DeleteBudgetAction"
     ]
     resources = ["*"]
+    condition {
+      test     = "StringNotLike"
+      variable = "aws:PrincipalARN"
+      values   = ["arn:aws:iam::*:role/OrganizationAccountAccessRole"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "deny_modify_vpc_tags" {
+  statement {
+    sid    = "DenyModifyVpcTags"
+    effect = "Deny"
+    actions = [
+      "ec2:DeleteTags",
+      "ec2:CreateTags"
+    ]
+    resources = ["arn:aws:ec2:*:*:vpc/*"]
     condition {
       test     = "StringNotLike"
       variable = "aws:PrincipalARN"

--- a/examples/organization/locals.tf
+++ b/examples/organization/locals.tf
@@ -147,8 +147,8 @@ locals {
       uuid = "6aefd914-cb87-4b6b-89d6-73ffbb55e565"
     }
     tags = {
-        AccountType = "sandbox"
-      }
+      AccountType = "sandbox"
+    }
   }]
 
 }


### PR DESCRIPTION
## Related Tasks

- Internal PR

## What

- Add sample for blocking.
- Fix formatting issues.

## Why

- The names of VPC resources are sensitive to other services which query them.
