### PR TITLE
[Nexus-611] feat: added permission boundary support

### DIFF
--- a/modules/sso/main.tf
+++ b/modules/sso/main.tf
@@ -17,6 +17,8 @@ resource "aws_ssoadmin_permissions_boundary_attachment" "this" {
   instance_arn       = local.sso_instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.this[each.key].arn
 
+  #  the two dynamic blocks are enforced to be mutually exclusive
+  #  sets customer_managed policy if not null
   dynamic "permissions_boundary" {
     for_each = each.value.permissions_boundary.customer_managed_policy_reference != null ? [each.value.permissions_boundary.customer_managed_policy_reference] : []
     content {
@@ -30,6 +32,7 @@ resource "aws_ssoadmin_permissions_boundary_attachment" "this" {
     }
   }
 
+  #  sets managed_policy_arn if not null
   dynamic "permissions_boundary" {
     for_each = each.value.permissions_boundary.managed_policy_arn != null ? [each.value.permissions_boundary.managed_policy_arn] : []
     content {

--- a/modules/sso/main.tf
+++ b/modules/sso/main.tf
@@ -4,7 +4,7 @@ resource "aws_ssoadmin_permission_set" "this" {
   name             = each.value.name
   description      = each.value.description
   instance_arn     = local.sso_instance_arn
-  session_duration = try(each.value.session_duration, "PT12H")
+  session_duration = each.value.session_duration
 }
 
 #  attaches permission boundaries

--- a/modules/sso/variables.tf
+++ b/modules/sso/variables.tf
@@ -13,6 +13,16 @@ variable "managed_permission_sets" {
     }))
   }))
   description = "List of the required Permission Sets that contain AWS Managed Policies"
+
+  validation {
+    condition = alltrue([
+      for ps in var.inline_permission_sets :
+      ps.permissions_boundary == null ||
+      (ps.permissions_boundary.managed_policy_arn != null) !=
+      (ps.permissions_boundary.customer_managed_policy_reference != null)
+    ])
+    error_message = "When permissions_boundary is set, exactly one of managed_policy_arn or customer_managed_policy_reference must be provided."
+  }
 }
 
 variable "inline_permission_sets" {
@@ -30,6 +40,16 @@ variable "inline_permission_sets" {
     }))
   }))
   description = "List of the required Permission Sets that are comprised of inline IAM Policies"
+
+  validation {
+    condition = alltrue([
+      for ps in var.inline_permission_sets :
+      ps.permissions_boundary == null ||
+      (ps.permissions_boundary.managed_policy_arn != null) !=
+      (ps.permissions_boundary.customer_managed_policy_reference != null)
+    ])
+    error_message = "When permissions_boundary is set, exactly one of managed_policy_arn or customer_managed_policy_reference must be provided."
+  }
 }
 
 variable "sso_groups" {

--- a/modules/sso/variables.tf
+++ b/modules/sso/variables.tf
@@ -3,7 +3,7 @@ variable "managed_permission_sets" {
     name              = string
     description       = string
     attached_policies = list(string)
-    session_duration  = optional(string)
+    session_duration  = optional(string, "PT12H")
     permissions_boundary = optional(object({
       managed_policy_arn = optional(string)
       customer_managed_policy_reference = optional(object({

--- a/modules/sso/variables.tf
+++ b/modules/sso/variables.tf
@@ -32,7 +32,7 @@ variable "inline_permission_sets" {
     name             = string
     description      = string
     inline_policy    = string
-    session_duration = optional(string)
+    session_duration = optional(string, "PT12H")
     permissions_boundary = optional(object({
       managed_policy_arn = optional(string)
       customer_managed_policy_reference = optional(object({

--- a/modules/sso/variables.tf
+++ b/modules/sso/variables.tf
@@ -16,7 +16,7 @@ variable "managed_permission_sets" {
 
   validation {
     condition = alltrue([
-      for ps in var.inline_permission_sets :
+      for ps in var.managed_permission_sets :
       ps.permissions_boundary == null ||
       (ps.permissions_boundary.managed_policy_arn != null) !=
       (ps.permissions_boundary.customer_managed_policy_reference != null)

--- a/modules/sso/variables.tf
+++ b/modules/sso/variables.tf
@@ -18,8 +18,10 @@ variable "managed_permission_sets" {
     condition = alltrue([
       for ps in var.managed_permission_sets :
       ps.permissions_boundary == null ||
-      (ps.permissions_boundary.managed_policy_arn != null) !=
-      (ps.permissions_boundary.customer_managed_policy_reference != null)
+      (
+        (try(ps.permissions_boundary.managed_policy_arn, null) != null) !=
+        (try(ps.permissions_boundary.customer_managed_policy_reference, null) != null)
+      )
     ])
     error_message = "When permissions_boundary is set, exactly one of managed_policy_arn or customer_managed_policy_reference must be provided."
   }
@@ -40,13 +42,14 @@ variable "inline_permission_sets" {
     }))
   }))
   description = "List of the required Permission Sets that are comprised of inline IAM Policies"
-
   validation {
     condition = alltrue([
       for ps in var.inline_permission_sets :
       ps.permissions_boundary == null ||
-      (ps.permissions_boundary.managed_policy_arn != null) !=
-      (ps.permissions_boundary.customer_managed_policy_reference != null)
+      (
+        (try(ps.permissions_boundary.managed_policy_arn, null) != null) !=
+        (try(ps.permissions_boundary.customer_managed_policy_reference, null) != null)
+      )
     ])
     error_message = "When permissions_boundary is set, exactly one of managed_policy_arn or customer_managed_policy_reference must be provided."
   }

--- a/modules/sso/variables.tf
+++ b/modules/sso/variables.tf
@@ -1,10 +1,34 @@
 variable "managed_permission_sets" {
-  type        = list(any)
+  type = list(object({
+    name              = string
+    description       = string
+    attached_policies = list(string)
+    session_duration  = optional(string)
+    permissions_boundary = optional(object({
+      managed_policy_arn = optional(string)
+      customer_managed_policy_reference = optional(object({
+        name = string
+        path = optional(string, "/")
+      }))
+    }))
+  }))
   description = "List of the required Permission Sets that contain AWS Managed Policies"
 }
 
 variable "inline_permission_sets" {
-  type        = list(any)
+  type = list(object({
+    name             = string
+    description      = string
+    inline_policy    = string
+    session_duration = optional(string)
+    permissions_boundary = optional(object({
+      managed_policy_arn = optional(string)
+      customer_managed_policy_reference = optional(object({
+        name = string
+        path = optional(string, "/")
+      }))
+    }))
+  }))
   description = "List of the required Permission Sets that are comprised of inline IAM Policies"
 }
 


### PR DESCRIPTION
## Related Tasks

Does this PR relate to other tasks?
No

## Depends on

Are there any other PRs that need to be merged first?
No

## What

What changes have been made within this PR?
Added the support for permission boundary for `managed_permission_sets` and `inline_permission_sets`.

## Why

Why are we submitting this PR? What is the context, engineering and business goals being satisfied by this PR?
Added the support for permission boundary to allow the attachment of restriction policies to allow the AU platform team to work on EU resources without infringing GDPR.

